### PR TITLE
set btn outside of if block

### DIFF
--- a/src/angular-zeroclipboard.js
+++ b/src/angular-zeroclipboard.js
@@ -47,9 +47,10 @@ directive('uiZeroclip', ['$document', '$window', 'uiZeroclipConfig',
             link: function(scope, elm, attrs) {
                 // config
                 ZeroClipboard.config(zeroclipConfig);
+                var btn = elm[0];
                 if (!attrs.id) {
                     attrs.$set('id', 'uiZeroclip' + _id);
-                    var btn = document.createElement('button');
+                    btn = document.createElement('button');
                     btn.appendChild(document.createTextNode(options.buttonText));
                     btn.setAttribute('data-clipboard-target', 'uiZeroclip' + _id);
                     btn.setAttribute('class', options.buttonClass);


### PR DESCRIPTION
Hi

First off, thanks for this lib. It saved me the effort :)

I was trying to use the lib to clip to an existing element on my page but could not get it to work. When I checked the source, I saw that the btn variable was only ever set in the if(!attrs.id) block and so the zeroclipboard client was not being created in the case where I was trying to clip to an element with an id.
