### PR TITLE
Fix for #13 - uiZeroclipConfig overrides previous configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ uiZeroclipConfigProvider.setZcConf({
 })
 ```
 
+If you already have your own configuration and don't want it to be overridden:
+
+```js
+uiZeroclipConfigProvider.setOverrideConfig(false);
+```
+
 The params is an object. and just same as [ZeroClipboard official config](https://github.com/zeroclipboard/zeroclipboard/blob/master/docs/api/ZeroClipboard.md#configuration-options)
 
 ## LICENSE

--- a/src/angular-zeroclipboard.js
+++ b/src/angular-zeroclipboard.js
@@ -15,12 +15,18 @@ angular.module('zeroclipboard', [])
         hoverClass: "zeroclipboard-is-hover",
         activeClass: "zeroclipboard-is-active"
     };
+    var _overrideConfig = true;
+
     this.setZcConf = function(zcConf) {
       angular.extend(_zeroclipConfig, zcConf);
     };
+    this.setOverrideConfig = function(overrideConfig) {
+      _overrideConfig = overrideConfig;
+    }
     this.$get = function() {
       return {
-        zeroclipConfig: _zeroclipConfig
+        zeroclipConfig: _zeroclipConfig,
+        overrideConfig: _overrideConfig
       };
     };
   })
@@ -46,7 +52,9 @@ angular.module('zeroclipboard', [])
             var _completeHnd;
 
             // config
-            ZeroClipboard.config(zeroclipConfig);
+            if(uiZeroclipConfig.overrideConfig) {
+              ZeroClipboard.config(zeroclipConfig);
+            }
 
             if (angular.isFunction(ZeroClipboard)) {
               scope.client = new ZeroClipboard(btn);
@@ -77,7 +85,7 @@ angular.module('zeroclipboard', [])
               }
               ZeroClipboard.destroy();
             });
-            
+
             scope.client.on('beforecopy', function (e) {
                 if (scope.onBeforeCopy) {
                     scope.$apply(function () {


### PR DESCRIPTION
Hi, as I said in #13, for some of us (in my case I'm using Ruby on Rails) it's easier to set the configuration in a different way. I like this angular module but I preferred to keep the configuration I already set.

Usage is pretty easy, if you don't want your configuration to be overridden, you just set that. It will work fine for current users, because the default is to do it.

Please let me know if this is change is fine, and I can add the details in the readme.md file