### PR TITLE
Fix memory leak

### DIFF
--- a/src/angular-zeroclipboard.js
+++ b/src/angular-zeroclipboard.js
@@ -96,6 +96,9 @@ angular.module('zeroclipboard', [])
 
             scope.$on('$destroy', function() {
               scope.client.off('complete', _completeHnd);
+              scope.client = null;
+              element.off();
+              ZeroClipboard.destroy();
             });
           }
         };


### PR DESCRIPTION
ZeroClipboard was not properly destroyed when the directive was destroyed. I detected the problem while profiling the memory.
Calling ZeroClipboard.destroy() on the $destroy event handler fixes the problem.