### PR TITLE
Destroy only the client context.

### DIFF
--- a/src/angular-zeroclipboard.js
+++ b/src/angular-zeroclipboard.js
@@ -96,10 +96,9 @@ angular.module('zeroclipboard', [])
           });
 
           scope.$on('$destroy', function() {
-            scope.client.off('complete', _completeHnd);
+            scope.client.destroy();
             scope.client = null;
             element.off();
-            ZeroClipboard.destroy();
           });
         }
       };


### PR DESCRIPTION
The `ZeroClipboard.destroy()` kill all zeroclipboard context. If you have it in two scopes and one of them is destroyed, you kill both clients.

This change destroy only one client and the others continue working fine.
